### PR TITLE
Fix issue with h5py version 3 string handling

### DIFF
--- a/dsch/backends/hdf5.py
+++ b/dsch/backends/hdf5.py
@@ -433,7 +433,10 @@ class String(_ItemNode):
         Returns:
             Node data.
         """
-        return self._storage[()]
+        if int(h5py.version.version.split('.')[0]) >= 3:
+            return self._storage[()].decode('utf8')
+        else:
+            return self._storage[()]
 
 
 class Time(data.Time, _ItemNode):


### PR DESCRIPTION
Starting with version 3 of h5py strings are stored as bytes. This PR adds a check for h5py's version and decodes the bytes to string if necessary. 